### PR TITLE
Added the Demo in ReadMe

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,6 +13,6 @@
       src="https://dummyimage.com/800x800/111/fff&text=Hover-me"
       data-preview="https://dummyimage.com/800x800/111/fff&text=1|https://dummyimage.com/800x800/111/fff&text=2|https://dummyimage.com/800x800/111/fff&text=3"
     />
-    <script src="../src/hover-preview.js"></script>
+    <script defer src='https://cdn.jsdelivr.net/gh/Avikki/hover-preview@main/dist/hover-preview.min.js'></script>
   </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -25,3 +25,6 @@ A vanilla js library to show preview images on hover.
 ```sh
 $ yarn build
 ```
+
+## Demo
+check the running example [here](https://hover-preview.surge.sh/)


### PR DESCRIPTION
I have added the demo link in the ReadMe file and also updated the example/index.html file
I have used [jsdelivr](https://www.jsdelivr.com) in order to access the hover-review.minified.js file instead of directly accesing the raw github file.
Cause in 2013, GitHub started using X-Content-Type-Options: nosniff, which instructs more modern browsers to enforce strict MIME type checking. It then returns the raw files in a MIME type returned by the server, preventing the browser from using the file as-intended (if the browser honors the setting).

You can read more about this [here](https://stackoverflow.com/questions/17341122/link-and-execute-external-javascript-file-hosted-on-github) 